### PR TITLE
Added apache/nginx vhost configuration with custom extra parameters by vhost

### DIFF
--- a/provision/roles/boilerplate-main/tasks/bootstrap/web.apache.yml
+++ b/provision/roles/boilerplate-main/tasks/bootstrap/web.apache.yml
@@ -10,4 +10,17 @@
     dest:  /opt/docker/etc/httpd/vhost.conf
     owner: root
     group: root
-    mode:  0775
+    mode:  0644
+
+- file:
+    path: "/opt/docker/etc/httpd/vhost.extra.d/"
+    state: directory
+
+- name: Deploy apache vhost with extra parameters
+  template:
+    src:   templates/apache/vhost-extra.conf.j2
+    dest:  /opt/docker/etc/httpd/vhost.extra.d/{{ item.serverName }}.conf
+    owner: root
+    group: root
+    mode:  0644
+  with_items: "{{ WEB.vhost }}"

--- a/provision/roles/boilerplate-main/tasks/bootstrap/web.nginx.yml
+++ b/provision/roles/boilerplate-main/tasks/bootstrap/web.nginx.yml
@@ -10,4 +10,18 @@
     dest:  /opt/docker/etc/nginx/vhost.conf
     owner: root
     group: root
-    mode:  0775
+    mode:  0644
+
+- file:
+    path: "/opt/docker/etc/nginx/vhost.extra.d/"
+    state: directory
+
+- name: Deploy nginx vhost with extra parameters
+  template:
+    src:   templates/nginx/vhost-extra.conf.j2
+    dest:  /opt/docker/etc/nginx/vhost.extra.d/{{ item.serverName }}.conf
+    owner: root
+    group: root
+    mode:  0644
+  with_items: "{{ WEB.vhost }}"
+

--- a/provision/roles/boilerplate-main/templates/apache/vhost-extra.conf.j2
+++ b/provision/roles/boilerplate-main/templates/apache/vhost-extra.conf.j2
@@ -1,0 +1,7 @@
+#######################################
+# vhost-extra for {{ item.serverName }}
+#######################################
+
+{% if item.vhost_extra is defined %}
+{{ item.vhost_extra }}
+{% endif %}

--- a/provision/roles/boilerplate-main/templates/apache/vhost.conf.j2
+++ b/provision/roles/boilerplate-main/templates/apache/vhost.conf.j2
@@ -7,31 +7,47 @@
 
 <VirtualHost *:80>
   ServerName "{{ vhost.serverName }}"
+{% if vhost.serverAlias is defined %}
   ServerAlias "{{ vhost.serverAlias }}"
+{% endif %}
   DocumentRoot "{{ vhost.documentRoot|default('<DOCUMENT_ROOT>') }}"
 
   UseCanonicalName Off
 
   <IfVersion < 2.4>
     Include /opt/docker/etc/httpd/vhost.common.d/*.conf
+{% if vhost.vhost_extra is defined %}
+    Include /opt/docker/etc/httpd/vhost.extra.d/{{ vhost.serverName }}.conf
+{% endif %}
   </IfVersion>
   <IfVersion >= 2.4>
     IncludeOptional /opt/docker/etc/httpd/vhost.common.d/*.conf
+{% if vhost.vhost_extra is defined %}
+    IncludeOptional /opt/docker/etc/httpd/vhost.extra.d/{{ vhost.serverName }}.conf
+{% endif %}
   </IfVersion>
 </VirtualHost>
 
 <VirtualHost *:443>
   ServerName "{{ vhost.serverName }}"
+{% if vhost.serverAlias is defined %}
   ServerAlias "{{ vhost.serverAlias }}"
+{% endif %}
   DocumentRoot "{{ vhost.documentRoot|default('<DOCUMENT_ROOT>') }}"
 
   UseCanonicalName Off
 
   <IfVersion < 2.4>
     Include /opt/docker/etc/httpd/vhost.common.d/*.conf
+{% if vhost.vhost_extra is defined %}
+    Include /opt/docker/etc/httpd/vhost.extra.d/{{ vhost.serverName }}.conf
+{% endif %}
   </IfVersion>
   <IfVersion >= 2.4>
     IncludeOptional /opt/docker/etc/httpd/vhost.common.d/*.conf
+{% if vhost.vhost_extra is defined %}
+    IncludeOptional /opt/docker/etc/httpd/vhost.extra.d/{{ vhost.serverName }}.conf
+{% endif %}
   </IfVersion>
 
   Include /opt/docker/etc/httpd/vhost.ssl.conf

--- a/provision/roles/boilerplate-main/templates/nginx/vhost-extra.conf.j2
+++ b/provision/roles/boilerplate-main/templates/nginx/vhost-extra.conf.j2
@@ -1,0 +1,7 @@
+#######################################
+# vhost-extra for {{ item.serverName }}
+#######################################
+
+{% if item.vhost_extra is defined %}
+{{ item.vhost_extra }}
+{% endif %}

--- a/provision/roles/boilerplate-main/templates/nginx/vhost.conf.j2
+++ b/provision/roles/boilerplate-main/templates/nginx/vhost.conf.j2
@@ -32,7 +32,7 @@ server {
 server {
     listen  443;
 
-    server_name  {{ vhost.serverName }} {{ vhost.serverAlias }};
+    server_name  {{ vhost.serverName }}{% if vhost.serverAlias is defined %} {{ vhost.serverAlias }}{% endif %};
 
     access_log   /dev/stdout;
     error_log    /dev/stdout info;

--- a/provision/roles/boilerplate-main/templates/nginx/vhost.conf.j2
+++ b/provision/roles/boilerplate-main/templates/nginx/vhost.conf.j2
@@ -8,7 +8,7 @@
 server {
     listen  80;
 
-    server_name  {{ vhost.serverName }} {{ vhost.serverAlias }};
+    server_name  {{ vhost.serverName }}{% if vhost.serverAlias is defined %} {{ vhost.serverAlias }}{% endif %};
 
     access_log   /dev/stdout;
     error_log    /dev/stdout info;
@@ -19,6 +19,10 @@ server {
     client_max_body_size 50m;
 
     include /opt/docker/etc/nginx/vhost.common.d/*.conf;
+
+{% if vhost.vhost_extra is defined %}
+    include /opt/docker/etc/nginx/vhost.extra.d/{{ vhost.serverName }}.conf
+{% endif %}
 }
 
 ##############
@@ -39,6 +43,9 @@ server {
     client_max_body_size 50m;
 
     include /opt/docker/etc/nginx/vhost.common.d/*.conf;
+{% if vhost.vhost_extra is defined %}
+    Include /opt/docker/etc/nginx/vhost.extra.d/{{ vhost.serverName }}.conf
+{% endif %}
     include /opt/docker/etc/nginx/vhost.ssl.conf;
 }
 


### PR DESCRIPTION
You can specify additional parameters by vhost with the key vhost_extra.

Here is an example: 
In the file etc/application.(developement|production).yml : 

WEB:
  vhost:
    - serverName: "docker.vm"
      serverAlias: "_.vm"
      vhost_extra: |
        RewriteEngine On
        RewriteRule ._ www.perdu.com

Also, I fixed the permissions on the vhost.conf file by removing the execute flag. 

The serverAlias is now optional, because we dont want to set the same *.domain.com for each vhost (a|b|c|...).domain.com.
